### PR TITLE
chore: Auto approve deploys

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Jumpstart Review Bot
-description: Automatically approves changes from develop to qa and from qa to main.
+description: Automatically approves changes from develop to qa and from qa to main. Also deploy PRs
 author: Nils Caspar
 
 branding:

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-const core = require("@actions/core"),
-  github = require("@actions/github");
+const core = require("@actions/core");
+const github = require("@actions/github");
 
-const token = core.getInput("github-token", { required: true }),
-  developBranch = core.getInput("develop"),
-  qaBranch = core.getInput("qa"),
-  mainBranch = core.getInput("main"),
-  client = new github.getOctokit(token);
+const token = core.getInput("github-token", { required: true });
+const developBranch = core.getInput("develop");
+const qaBranch = core.getInput("qa");
+const mainBranch = core.getInput("main");
+const client = new github.getOctokit(token);
 
 const approveSrcTarget = {
   [developBranch]: qaBranch,
@@ -14,12 +14,14 @@ const approveSrcTarget = {
 
 async function run() {
   try {
-    const pr =  github.context.payload.pull_request,
-      action = github.context.payload.action,
-      prSrc = pr.head.ref,
-      prTarget = pr.base.ref;
-      owner = github.context.repo.owner,
-      repo = github.context.repo.repo;
+    const pr =  github.context.payload.pull_request;
+    const action = github.context.payload.action;
+    const prSrc = pr.head.ref;
+    const prTarget = pr.base.ref;
+    const owner = github.context.repo.owner;
+    const repo = github.context.repo.repo;
+    const title = pr.title;
+    const pull_number = github.context.payload.pull_request.number;
 
     core.info(`Pull Request src: "${prSrc}", target: "${prTarget}"`);
 
@@ -27,7 +29,15 @@ async function run() {
       client.pulls.createReview({
         owner,
         repo,
-        pull_number: github.context.payload.pull_request.number,
+        pull_number: pull_number,
+        body: 'Looks good to me :shipit:',
+        event: 'APPROVE',
+      })
+    } else if (title.startsWith("Deploy: release v" && prTarget == developBranch)) {
+      client.pulls.createReview({
+        owner,
+        repo,
+        pull_number: pull_number,
         body: 'Looks good to me :shipit:',
         event: 'APPROVE',
       })
@@ -35,7 +45,7 @@ async function run() {
       client.pulls.createReview({
         owner,
         repo,
-        pull_number: github.context.payload.pull_request.number,
+        pull_number: pull_number,
         body: `I can't automatically approve changes from "${prSrc}" to "${prTarget}. A human will have to review this. :robot:`,
         event: 'COMMENT',
       })


### PR DESCRIPTION
I have to wait for somebody to approve these: https://github.com/Jumpstart-Me/jumpstart-backend/pull/5293
which is not necessary. this PR makes them auto-approved

also, do node_modules need to be checked in?

## Ticket(s)

<!-- Link to the relevant GitHub ticket(s) -->

## Summary

<!-- What does this PR do? -->

## Screenshots

<!-- If this changes UI, provide some screenshots -->
